### PR TITLE
Replace TRN_STREET_RETIRED with LRS sources in step_two

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -14,7 +14,8 @@ SDE = r"E:\HRM\Scripts\SDE\SQL\dev_RW_sdeadm.sde"
 
 TRN_STREET = os.path.join(SDE, "SDEADM.TRN_streets_routes", "SDEADM.TRN_street")
 TRN_STREET_RIVA = os.path.join(SDE, "SDEADM.TRN_STREET_RIVA")
-TRN_STREET_RETIRED = os.path.join(SDE, "SDEADM.TRN_street_retired")
+TRNLRS_SEGMENTED = os.path.join(SDE, "SDEADM.TRNLRS_segmented_street_events")
+E_STREET_STATUS = os.path.join(SDE, "SDEADM.TRNLRS", "SDEADM.E_StreetStatus")
 
 PROJECT_DIR = os.path.dirname(os.getcwd())
 SCRIPTS_DIR = os.path.join(PROJECT_DIR, "scripts")
@@ -125,84 +126,61 @@ def step_two_update_retired_streets(trn_street_riva, local_gdb):
 
     print("\nStarting Step 2: Updating Retired Streets...")
 
-    # •	Create a relate between TRN_STREET_RIVA and TRN_street using FDMID as common attribute
-    # •	Create a relate between TRN_street_riva and TRN_street_retired using FDMID as common attribute
-
-    # •	Select all records in TRN_street and relate to TRN_street_riva
-    # •	Reverse selection set in the TRN_street_riva table
-    # •	In the TRN_street_riva table, remove from selection set records that meet the following condition: DATE_RET IS NOT NULL
-    # TODO: Get all records in TRN_STREET_RIVA that are NOT in TRN_street and where DATE_RET IS NOT NULL
+    # Build DATE_ACCEPT lookup from E_StreetStatus keyed by ROUTE_ID (used as DATE_ACT)
+    print("Building DATE_ACCEPT lookup from E_StreetStatus...")
+    street_status_date_accept = {}
+    for row in arcpy.da.SearchCursor(E_STREET_STATUS, ["ROUTEID", "DATE_ACCEPT"]):
+        routeid, date_accept = row
+        if routeid not in street_status_date_accept:
+            street_status_date_accept[routeid] = date_accept
 
     print("Getting records in TRN_STREET_RIVA that are no longer in TRN_STREET...")
+    trn_street_fdmids = set(x[0] for x in arcpy.da.SearchCursor(TRN_STREET, ['FDMID']))
 
-    trn_street_fdmids = list(set([x[0] for x in arcpy.da.SearchCursor(TRN_STREET, ['FDMID', ])]))  # 1pk records
-
-    riva_retired_street_fdmids = list()  # 260 - 700004812, 700008166 --- 700013207
-
-    for row in arcpy.da.SearchCursor(trn_street_riva,["FDMID", ], "DATE_RET IS NOT NULL"):
+    # FDMIDs in RIVA not yet retired that are absent from TRN_STREET
+    riva_retired_fdmids = set()
+    for row in arcpy.da.SearchCursor(trn_street_riva, ["FDMID"], "DATE_RET IS NULL"):
         fdmid = row[0]
-
         if fdmid not in trn_street_fdmids:
-            riva_retired_street_fdmids.append(fdmid)
+            riva_retired_fdmids.add(fdmid)
 
-    # •	If no records remain, this means there are no new retired streets that need to be updated in the TRN_STREET_RIVA table.
-    # If there are records meet selection query, continue with next step
-    if riva_retired_street_fdmids:
-        # •	Relate the selection set in TRN_street_riva to TRN_street_retired
-        # •	Save selection set to a new line feature class called TRN_street_new_retired_streets_riva
+    if not riva_retired_fdmids:
+        print("No new retired streets to update.")
+        return
 
-        # Get all retired streets from TRN_street_retired
-        trn_street_new_retired_streets_riva = arcpy.Select_analysis(
-            in_features=TRN_STREET_RETIRED,
-            out_feature_class=os.path.join(local_gdb, "TRN_street_new_retired_streets_riva")
-        )
-        with arcpy.da.UpdateCursor(trn_street_new_retired_streets_riva, ["FDMID"]) as cursor:
+    # Pull retirement data from TRNLRS_segmented_street_events for matching FDMIDs.
+    # TO_DATE IS NOT NULL = retired in LRS; ROUTE_ID links to E_StreetStatus.ROUTEID.
+    print("Querying LRS for retirement data...")
+    retired_data = {}
+    for row in arcpy.da.SearchCursor(
+        TRNLRS_SEGMENTED,
+        ["FDMID", "TO_DATE", "OLD_FDMID", "SHAPE@LENGTH", "ROUTE_ID"],
+        "TO_DATE IS NOT NULL AND FDMID IS NOT NULL"
+    ):
+        fdmid, to_date, old_fdmid, shape_length, route_id = row
+        if fdmid in riva_retired_fdmids and fdmid not in retired_data:
+            retired_data[fdmid] = {
+                'date_ret': to_date,
+                'old_fdmid': old_fdmid,
+                'shape_length': shape_length,
+                'date_act': street_status_date_accept.get(route_id),
+            }
 
-            for row in cursor:
-                fdmid = row[0]
-
-                if fdmid not in riva_retired_street_fdmids:
-                    cursor.deleteRow()
-
-        del cursor
-
-        # •	This output will be joined to the TRN_street_riva table, to update the DATE_RET field, shape.length, and anything else.
-        # TODO: Update TRN_STREET_RIVA with retired street data
-
-        # TRN_STREET_RIVA.DATE_RET = TRN_street_new_retired_streets_riva.DATE_RET
-        # TRN_STREET_RIVA.DATE_REV = Today's Date
-        # TRN_STREET_RIVA.OLD_FDMID = TRN_street_new_retired_streets_riva.OLD_FDMID
-        # TRN_STREET_RIVA.shape_length = TRN_street_new_retired_streets_riva.shape_length
-
-        new_retired_streets_data = {
-            row[0]: row for row in arcpy.da.SearchCursor(
-                trn_street_new_retired_streets_riva,
-                ["FDMID", "DATE_RET", "OLD_FDMID", "SHAPE@LENGTH", "DATE_ACT"]
-            )
-        }
-
-        # •	Create a join between the TRN_STREET_RIVA and TRN_street_new_retired_streets_riva using FDMID as common attribute,
-        #   and only keep the matching records.
-        # •	Start an edit session
-        # •	Update the following attributes using the Field Calculator tool (right-clicking on attribute field column heading)
-
-        with arcpy.da.UpdateCursor(trn_street_riva, ["FDMID", "DATE_RET", "DATE_REV", "OLD_FDMID", "SHAPE_LENGTH", "DATE_ACT"]) as cursor:
-
-            for row in cursor:
-                fdmid = row[0]
-
-                if fdmid in new_retired_streets_data:
-                    # Update row
-                    update_info = new_retired_streets_data.get(fdmid)
-
-                    row[1] = update_info[1]  # DATE_RET
-                    row[2] = datetime.today()  # DATE_REV
-                    row[3] = update_info[2]  # OLD_FDMID
-                    row[4] = update_info[3]  # SHAPE.LENGTH
-                    row[5] = update_info[4]  # DATE_ACT
-
-                    cursor.updateRow(row)
-                    print(f"\tUpdated {fdmid}")
+    with arcpy.da.UpdateCursor(
+        trn_street_riva,
+        ["FDMID", "DATE_RET", "DATE_REV", "OLD_FDMID", "SHAPE_LENGTH", "DATE_ACT"]
+    ) as cursor:
+        for row in cursor:
+            fdmid = row[0]
+            if fdmid in retired_data:
+                data = retired_data[fdmid]
+                row[1] = data['date_ret']
+                row[2] = datetime.today()
+                row[3] = data['old_fdmid']
+                row[4] = data['shape_length']
+                row[5] = data['date_act']
+                cursor.updateRow(row)
+                print(f"\tUpdated FDMID: {fdmid}")
 
 
 def step_three_updating_existing(trn_street_riva):


### PR DESCRIPTION
Retired streets are now sourced from TRNLRS_segmented_street_events (TO_DATE IS NOT NULL) instead of the deprecated TRN_STREET_RETIRED table. DATE_ACT is populated from E_StreetStatus.DATE_ACCEPT joined via ROUTE_ID.

https://claude.ai/code/session_01Lwrxp2nXxPVujoRk6QqCAU