### PR TITLE
Document trn_street_assets.py ETL orchestrator and data flow

### DIFF
--- a/asset_accounting_streets.md
+++ b/asset_accounting_streets.md
@@ -66,6 +66,134 @@ This is a full truncate-and-reload; there is no incremental update. Row counts s
 
 ---
 
+## scripts/trn_street_assets.py — Detailed Breakdown
+
+The ETL orchestrator that keeps `TRN_STREET_RIVA` in sync with `TRNLRS_TRN_STREET_VW`. It runs four functions in sequence against a **local scratch.gdb** copy of RIVA; the edited local copy is then used as the source for the final truncate-and-reload into `ASSET_ACCOUNTING.TRN_STREET_ASSETS`.
+
+### Global Configuration
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `SDE` | `.sde` file path | Active connection (dev/qa/prod RW) — edit before running |
+| `TRN_STREET` | `SDEADM.TRNLRS_TRN_STREET_VW` | Authoritative street source (LRS view) |
+| `TRN_STREET_RIVA` | `SDEADM.TRN_STREET_RIVA` | Working layer being updated |
+| `TRNLRS_SEGMENTED` | `SDEADM.TRNLRS_segmented_street_events` | LRS event table for retirement data |
+| `E_STREET_STATUS` | `SDEADM.TRNLRS\SDEADM.E_StreetStatus` | LRS event table for `DATE_ACCEPT` lookup |
+
+---
+
+### Step 1 — `step_one_new_hrm_streets()`
+
+**Purpose:** Find streets in `TRNLRS_TRN_STREET_VW` (owned by HRM, not yet retired) that are absent from `TRN_STREET_RIVA`, and insert them.
+
+**Filters applied:**
+- `OWN LIKE 'HRM'` — only HRM-owned streets from the source
+- `DATE_RET IS NULL` on `TRN_STREET_RIVA` — ignore already-retired RIVA records when building the exclusion set
+
+**Logic:**
+1. Create (or reuse) `scratch.gdb` in the scripts directory.
+2. Export `TRN_STREET_RIVA` into `scratch.gdb` as a local backup copy.
+3. Select all HRM-owned streets from `TRN_STREET` → `TRN_street_HRMowned` in scratch.gdb.
+4. Copy that selection → `trn_street_new_streets_riva`.
+5. Collect all `FDMID`s currently in `TRN_STREET_RIVA` where `DATE_RET IS NULL`.
+6. Delete from `trn_street_new_streets_riva` any row whose `FDMID` is already in RIVA → leaving only genuinely new streets.
+7. Export the remainder to `TBL_new_streets_for_riva`.
+8. `Append` `TBL_new_streets_for_riva` into the local RIVA copy (`schema_type="NO_TEST"`).
+
+**Returns:** `(trn_street_riva_copy, local_gdb)` — passed to Steps 2–4.
+
+**Fields written to RIVA:** all columns carried over from `TRN_STREET` via `NO_TEST` append (no field mapping).
+
+---
+
+### Step 2 — `step_two_update_retired_streets(trn_street_riva, local_gdb)`
+
+**Purpose:** Detect RIVA records that have disappeared from `TRN_STREET` (i.e., retired in the LRS) and stamp them with retirement metadata.
+
+**Sources queried:**
+| Table | Fields read | Why |
+|---|---|---|
+| `E_StreetStatus` | `ROUTEID`, `DATE_ACCEPT` | Builds a `route_id → date_accept` lookup used to populate `DATE_ACT` |
+| `TRN_STREET` | `FDMID` | Full set of active FDMIDs in the authoritative source |
+| `TRNLRS_segmented_street_events` | `FDMID`, `TO_DATE`, `OLD_FDMID`, `SHAPE@LENGTH`, `ROUTE_ID` | Retirement date, predecessor FDMID, and updated length |
+| local RIVA copy | `FDMID` (`DATE_RET IS NULL`) | Active RIVA rows that are candidates for retirement |
+
+**Logic:**
+1. Build `street_status_date_accept` dict: `ROUTEID → DATE_ACCEPT` (first occurrence wins).
+2. Collect `trn_street_fdmids` — every FDMID currently in `TRN_STREET`.
+3. Walk active RIVA rows; any `FDMID` not in `trn_street_fdmids` is added to `riva_retired_fdmids`.
+4. Query `TRNLRS_SEGMENTED` where `TO_DATE IS NOT NULL` to get retirement metadata for each candidate FDMID.
+5. Update RIVA rows in `riva_retired_fdmids`:
+
+| RIVA Field | Value set |
+|---|---|
+| `DATE_RET` | `TO_DATE` from `TRNLRS_SEGMENTED` |
+| `DATE_REV` | `datetime.today()` (processing date) |
+| `OLD_FDMID` | `OLD_FDMID` from `TRNLRS_SEGMENTED` |
+| `SHAPE_LENGTH` | updated length from `TRNLRS_SEGMENTED` |
+| `DATE_ACT` | `DATE_ACCEPT` from `E_StreetStatus` via `ROUTE_ID` |
+
+Short-circuits with a message if `riva_retired_fdmids` is empty.
+
+---
+
+### Step 3 — `step_three_updating_existing(trn_street_riva)`
+
+**Purpose:** For active RIVA records that still exist in `TRN_STREET` but whose geometry or attributes have changed, sync the updated values into the local RIVA copy.
+
+**Change detection:** compares `SHAPE_LENGTH` between RIVA and `TRN_STREET`. If lengths match, the row is skipped (geometry is assumed unchanged).
+
+> Note: the script comments acknowledge length equality is rare — in practice nearly every active segment is updated.
+
+**Source query on `TRN_STREET`:** loads all active streets into a dict keyed by `FDMID`, carrying:
+`SHAPE@LENGTH`, `FULL_NAME`, `FROM_STR`, `TO_STR`, `GSA_LEFT`, `OLD_FDMID`, `DATE_ACT`, `SYS_DATE`
+
+**Cursor on RIVA:** `DATE_RET IS NULL` — only active segments.
+
+**Fields written per changed row:**
+
+| RIVA Field | Calculation |
+|---|---|
+| `SHAPE_LENGTH` | `TRN_STREET.SHAPE@LENGTH` |
+| `SHORT_DESC` | `FULL_NAME + " (" + FROM_STR + " TO " + TO_STR + ")"` |
+| `LONG_DESC` | `FULL_NAME + " " + GSA_LEFT` |
+| `OLD_FDMID` | `TRN_STREET.OLD_FDMID` |
+| `DATE_REV` | `datetime.today()` |
+| `DATE_ACT` | `TRN_STREET.DATE_ACT` |
+| `SYS_DATE` | `TRN_STREET.SYS_DATE` |
+
+---
+
+### Step 4 — `step_four_validation_review(local_gdb)`
+
+**Purpose:** QA check on the net-new streets inserted by Step 1. Reports null/blank counts for `SHORT_DESC` and `LONG_DESC` — fields that must not be empty before loading to `ASSET_ACCOUNTING`.
+
+**Source:** `TBL_new_streets_for_riva` in `scratch.gdb` (created by Step 1).
+
+**Output:** Printed summary — total row count and per-field null/blank count with percentage. Returns `null_counts` dict.
+
+**Not a hard stop:** Step 4 does not halt or roll back; it reports problems for manual review. Any blanks flagged here should be QA'd before running the truncate-and-reload into `ASSET_ACCOUNTING.TRN_STREET_ASSETS`.
+
+---
+
+### Execution Order and Data Flow
+
+```
+scratch.gdb/TRN_STREET_RIVA  ←──── Step 1 (INSERT new HRM streets)
+         │
+         ├── Step 2 (UPDATE DATE_RET / DATE_REV / OLD_FDMID on retired rows)
+         │
+         ├── Step 3 (UPDATE SHAPE_LENGTH / SHORT_DESC / LONG_DESC / DATE_REV on changed rows)
+         │
+         └── Step 4 (QA: report null SHORT_DESC / LONG_DESC in TBL_new_streets_for_riva)
+                    ↓
+    Manual: TRUNCATE + INSERT into ASSET_ACCOUNTING.TRN_STREET_ASSETS
+```
+
+**Important:** Steps 2–4 all receive the same local RIVA copy path (`trn_street_riva_local`) returned by Step 1. The three ETL steps are commented out in `__main__` by default — uncomment selectively before running.
+
+---
+
 ## Open Questions
 
 | Question | Status |


### PR DESCRIPTION
## Summary
Added comprehensive documentation for the `scripts/trn_street_assets.py` ETL orchestrator, detailing its four-step process for keeping `TRN_STREET_RIVA` in sync with the authoritative LRS street source.

## Changes
- **Global Configuration table:** Documents the five key SDE objects and file paths used throughout the script
- **Step 1 — New HRM Streets:** Explains the logic for identifying and inserting streets from `TRNLRS_TRN_STREET_VW` that are absent from `TRN_STREET_RIVA`, including the HRM ownership filter and duplicate detection
- **Step 2 — Retired Streets:** Details how the script detects streets that have been retired in the LRS (disappeared from the source) and stamps them with retirement metadata (`DATE_RET`, `DATE_REV`, `OLD_FDMID`, `SHAPE_LENGTH`, `DATE_ACT`)
- **Step 3 — Update Existing:** Documents the change detection mechanism (comparing `SHAPE_LENGTH`) and the field synchronization logic for active streets with geometry or attribute changes
- **Step 4 — Validation Review:** Describes the QA check that reports null/blank counts for required description fields before final load to `ASSET_ACCOUNTING`
- **Execution Flow diagram:** Visual representation of how the four steps process the local scratch.gdb copy sequentially before the final truncate-and-reload

## Notable Details
- Clarifies that the script operates on a local `scratch.gdb` copy of RIVA, with all edits applied there before the final load to production
- Documents the data sources queried in Step 2 (E_StreetStatus, TRNLRS_segmented_street_events) and their specific fields
- Notes that Step 4 is informational only and does not halt execution — manual QA is required before the final load
- Highlights that Steps 2–4 are commented out by default in `__main__` and must be uncommented selectively

https://claude.ai/code/session_01Mk8XgNkkShb9hufzrpbSrF