### PR TITLE
fix: re-raise exception in step_one_new_hrm_streets instead of swallo…

### DIFF
--- a/scripts/trn_street_assets.py
+++ b/scripts/trn_street_assets.py
@@ -115,7 +115,7 @@ def step_one_new_hrm_streets():
         return trn_street_riva_copy, local_gdb
 
     except Exception as e:
-        print(e)
+        raise RuntimeError(f"step_one_new_hrm_streets failed: {e}") from e
 
 
 def step_two_update_retired_streets(trn_street_riva, local_gdb):


### PR DESCRIPTION
…wing it

The bare except/print caused the function to return None, producing a misleading TypeError at the call site. Re-raising surfaces the real ArcPy error with full context.

https://claude.ai/code/session_01Mk8XgNkkShb9hufzrpbSrF