### PR TITLE
Add SHORT_DESC and LONG_DESC fields with field mapping for street append

### DIFF
--- a/scripts/trn_street_assets.py
+++ b/scripts/trn_street_assets.py
@@ -82,40 +82,49 @@ def step_one_new_hrm_streets(local_gdb: str):
             os.path.join(local_gdb, "new_streets_for_riva")
         )[0]
 
-        # Align source field names to match TRN_STREET_RIVA before appending.
-        # Append uses NO_TEST (name-based matching), so source fields with different
-        # names must be renamed here or they will be silently dropped.
-        print("\nAligning source field names to match TRN_STREET_RIVA schema...")
-        field_renames = [
-            ("FROM_STR",    "FROM_STREET"),
-            ("TO_STR",      "TO_STREET"),
-            ("GSA_LEFT",    "GSA_NAME"),
-            ("ADDDATE",     "DATE_ACT"),
-            ("MODDATE",     "SYS_DATE"),
-            ("ST_CLASS",    "PST_CLASS"),
-            ("STR_CODE_L",  "STR_CODE"),
-        ]
-        for old_name, new_name in field_renames:
-            arcpy.AlterField_management(tbl_new_streets_for_riva, old_name, new_name)
-            print(f"\tRenamed {old_name} -> {new_name}")
-
-        # SHORT_DESC and LONG_DESC do not exist on the source — add and compute them.
+        # SHORT_DESC and LONG_DESC are absent from the source — add and compute them
+        # before building the field mapping so addTable picks them up.
         print("\nAdding and computing SHORT_DESC and LONG_DESC...")
         arcpy.AddField_management(tbl_new_streets_for_riva, "SHORT_DESC", "TEXT", field_length=255)
         arcpy.AddField_management(tbl_new_streets_for_riva, "LONG_DESC", "TEXT", field_length=255)
 
         with arcpy.da.UpdateCursor(
             tbl_new_streets_for_riva,
-            ["FULL_NAME", "FROM_STREET", "TO_STREET", "GSA_NAME", "SHORT_DESC", "LONG_DESC"]
+            ["FULL_NAME", "FROM_STR", "TO_STR", "GSA_LEFT", "SHORT_DESC", "LONG_DESC"]
         ) as cursor:
             for row in cursor:
-                full_name   = row[0] or ""
-                from_street = row[1] or ""
-                to_street   = row[2] or ""
-                gsa_name    = row[3] or ""
-                row[4] = f"{full_name} ({from_street} TO {to_street})"
-                row[5] = f"{full_name} ({gsa_name})"
+                full_name = row[0] or ""
+                from_str  = row[1] or ""
+                to_str    = row[2] or ""
+                gsa_left  = row[3] or ""
+                row[4] = f"{full_name} ({from_str} TO {to_str})"
+                row[5] = f"{full_name} ({gsa_left})"
                 cursor.updateRow(row)
+
+        # Build FieldMappings: load all source fields as pass-throughs, then override
+        # the output name for fields whose source name differs from the target name.
+        print("\nBuilding field mappings for append...")
+        field_mappings = arcpy.FieldMappings()
+        field_mappings.addTable(tbl_new_streets_for_riva)
+
+        field_renames = {
+            "FROM_STR":   "FROM_STREET",
+            "TO_STR":     "TO_STREET",
+            "GSA_LEFT":   "GSA_NAME",
+            "ADDDATE":    "DATE_ACT",
+            "MODDATE":    "SYS_DATE",
+            "ST_CLASS":   "PST_CLASS",
+            "STR_CODE_L": "STR_CODE",
+        }
+        for source_name, target_name in field_renames.items():
+            idx = field_mappings.findFieldMapIndex(source_name)
+            if idx == -1:
+                continue
+            fm = field_mappings.getFieldMap(idx)
+            out_field = fm.outputField
+            out_field.name = target_name
+            fm.outputField = out_field
+            field_mappings.replaceFieldMap(idx, fm)
 
         # APPEND
         trn_street_riva_copy = os.path.join(local_gdb, 'TRN_STREET_RIVA')
@@ -131,7 +140,8 @@ def step_one_new_hrm_streets(local_gdb: str):
         arcpy.Append_management(
             inputs=tbl_new_streets_for_riva,
             target=trn_street_riva_copy,
-            schema_type="NO_TEST"
+            schema_type="NO_TEST",
+            field_mapping=field_mappings
         )
 
         return trn_street_riva_copy, local_gdb

--- a/scripts/trn_street_assets.py
+++ b/scripts/trn_street_assets.py
@@ -82,6 +82,41 @@ def step_one_new_hrm_streets(local_gdb: str):
             os.path.join(local_gdb, "new_streets_for_riva")
         )[0]
 
+        # Align source field names to match TRN_STREET_RIVA before appending.
+        # Append uses NO_TEST (name-based matching), so source fields with different
+        # names must be renamed here or they will be silently dropped.
+        print("\nAligning source field names to match TRN_STREET_RIVA schema...")
+        field_renames = [
+            ("FROM_STR",    "FROM_STREET"),
+            ("TO_STR",      "TO_STREET"),
+            ("GSA_LEFT",    "GSA_NAME"),
+            ("ADDDATE",     "DATE_ACT"),
+            ("MODDATE",     "SYS_DATE"),
+            ("ST_CLASS",    "PST_CLASS"),
+            ("STR_CODE_L",  "STR_CODE"),
+        ]
+        for old_name, new_name in field_renames:
+            arcpy.AlterField_management(tbl_new_streets_for_riva, old_name, new_name)
+            print(f"\tRenamed {old_name} -> {new_name}")
+
+        # SHORT_DESC and LONG_DESC do not exist on the source — add and compute them.
+        print("\nAdding and computing SHORT_DESC and LONG_DESC...")
+        arcpy.AddField_management(tbl_new_streets_for_riva, "SHORT_DESC", "TEXT", field_length=255)
+        arcpy.AddField_management(tbl_new_streets_for_riva, "LONG_DESC", "TEXT", field_length=255)
+
+        with arcpy.da.UpdateCursor(
+            tbl_new_streets_for_riva,
+            ["FULL_NAME", "FROM_STREET", "TO_STREET", "GSA_NAME", "SHORT_DESC", "LONG_DESC"]
+        ) as cursor:
+            for row in cursor:
+                full_name   = row[0] or ""
+                from_street = row[1] or ""
+                to_street   = row[2] or ""
+                gsa_name    = row[3] or ""
+                row[4] = f"{full_name} ({from_street} TO {to_street})"
+                row[5] = f"{full_name} ({gsa_name})"
+                cursor.updateRow(row)
+
         # APPEND
         trn_street_riva_copy = os.path.join(local_gdb, 'TRN_STREET_RIVA')
 
@@ -96,7 +131,7 @@ def step_one_new_hrm_streets(local_gdb: str):
         arcpy.Append_management(
             inputs=tbl_new_streets_for_riva,
             target=trn_street_riva_copy,
-            schema_type="NO_TEST"  # STR_CODE yields to null
+            schema_type="NO_TEST"
         )
 
         return trn_street_riva_copy, local_gdb


### PR DESCRIPTION
## Summary
Enhanced the street asset import process to automatically generate missing description fields and implement proper field mapping during the append operation to handle source-to-target field name transformations.

## Key Changes
- **Added SHORT_DESC and LONG_DESC fields**: These fields were absent from the source data but required by the target schema. They are now computed before the append operation:
  - `SHORT_DESC`: Combines full street name with from/to street range
  - `LONG_DESC`: Combines full street name with GSA name
  
- **Implemented field mapping logic**: Created a `FieldMappings` object to handle field name transformations between source and target schemas:
  - `FROM_STR` → `FROM_STREET`
  - `TO_STR` → `TO_STREET`
  - `GSA_LEFT` → `GSA_NAME`
  - `ADDDATE` → `DATE_ACT`
  - `MODDATE` → `SYS_DATE`
  - `ST_CLASS` → `PST_CLASS`
  - `STR_CODE_L` → `STR_CODE`

- **Updated Append_management call**: Now passes the field mapping to ensure proper field alignment during the append operation

## Implementation Details
- Uses `arcpy.da.UpdateCursor` to efficiently populate the new description fields with computed values
- Field mapping is built dynamically, gracefully skipping any source fields that don't exist (using `findFieldMapIndex` check)
- The mapping is applied to the `Append_management` call to ensure schema compatibility

https://claude.ai/code/session_01AZEfqGNcsiqcjSdyTPGTDP