### PR TITLE
Fix field mapping by switching to FIELD_MAPPING_ONLY schema type

### DIFF
--- a/scripts/trn_street_assets.py
+++ b/scripts/trn_street_assets.py
@@ -140,7 +140,7 @@ def step_one_new_hrm_streets(local_gdb: str):
         arcpy.Append_management(
             inputs=tbl_new_streets_for_riva,
             target=trn_street_riva_copy,
-            schema_type="NO_TEST",
+            schema_type="FIELD_MAPPING_ONLY",
             field_mapping=field_mappings
         )
 


### PR DESCRIPTION
NO_TEST ignores the field_mapping parameter and falls back to name-based matching, so renamed fields (FROM_STR->FROM_STREET, GSA_LEFT->GSA_NAME, etc.) were silently dropped. FIELD_MAPPING_ONLY makes the FieldMappings object authoritative: all source fields are covered by addTable(), and the rename overrides correctly route each source field to its target.

https://claude.ai/code/session_01AZEfqGNcsiqcjSdyTPGTDP