### PR TITLE
Refactor TRN_STREET_RIVA append logic with improved field mapping

### DIFF
--- a/scripts/trn_street_assets.py
+++ b/scripts/trn_street_assets.py
@@ -109,11 +109,23 @@ def step_one_new_hrm_streets(local_gdb: str):
 
                 cursor.updateRow(row)
 
-        # Build FieldMappings: load all source fields as pass-throughs, then override
-        # the output name for fields whose source name differs from the target name.
+        # APPEND
+        trn_street_riva_copy = os.path.join(local_gdb, 'TRN_STREET_RIVA')
+
+        # Export TRN_STREET_RIVA to local workspace before building field mappings
+        # so the target table exists when addTable() is called.
+        print("\nExporting TRN_STREET_RIVA to local workspace...")
+        arcpy.TableToGeodatabase_conversion(
+            Input_Table=TRN_STREET_RIVA,
+            Output_Geodatabase=local_gdb
+        )
+
+        # Build FieldMappings from the target, then wire each renamed source field
+        # into the correct target field slot. Same-name fields are matched automatically
+        # by NO_TEST without needing explicit entries.
         print("\nBuilding field mappings for append...")
         field_mappings = arcpy.FieldMappings()
-        field_mappings.addTable(tbl_new_streets_for_riva)
+        field_mappings.addTable(trn_street_riva_copy)
 
         field_renames = {
             "FROM_STR": "FROM_STREET",
@@ -127,32 +139,20 @@ def step_one_new_hrm_streets(local_gdb: str):
 
         for source_name, target_name in field_renames.items():
 
-            idx = field_mappings.findFieldMapIndex(source_name)
+            idx = field_mappings.findFieldMapIndex(target_name)
 
             if idx == -1:
                 continue
 
             fm = field_mappings.getFieldMap(idx)
-            out_field = fm.outputField
-            out_field.name = target_name
-            fm.outputField = out_field
+            fm.addInputField(tbl_new_streets_for_riva, source_name)
             field_mappings.replaceFieldMap(idx, fm)
-
-        # APPEND
-        trn_street_riva_copy = os.path.join(local_gdb, 'TRN_STREET_RIVA')
-
-        # Export TRN_STREET_RIVA to local workspace for backup purposes
-        print("\nExporting TRN_STREET_RIVA to local workspace...")
-        arcpy.TableToGeodatabase_conversion(
-            Input_Table=TRN_STREET_RIVA,
-            Output_Geodatabase=local_gdb
-        )
 
         print(f"\nAppending new streets into RIVA table...")
         arcpy.Append_management(
             inputs=tbl_new_streets_for_riva,
             target=trn_street_riva_copy,
-            schema_type="FIELD_MAPPING_ONLY",
+            schema_type="NO_TEST",
             field_mapping=field_mappings
         )
 


### PR DESCRIPTION
## Summary
Refactored the field mapping and append logic for the TRN_STREET_RIVA table to improve clarity and correctness. The changes reorganize the code flow and update the field mapping strategy to use explicit input field mapping instead of output field renaming.

## Key Changes
- **Reordered operations**: Moved the TRN_STREET_RIVA export to occur before field mapping setup, ensuring the target table exists when `addTable()` is called
- **Updated field mapping approach**: Changed from modifying output field names to explicitly adding input fields from the source table using `addInputField()`, which is more robust for handling field name mismatches
- **Changed append schema type**: Updated from `FIELD_MAPPING_ONLY` to `NO_TEST` to allow automatic matching of same-name fields while using explicit mappings for renamed fields
- **Fixed field lookup logic**: Changed `findFieldMapIndex()` to search for the target field name instead of the source name, which aligns with the new mapping strategy

## Implementation Details
The refactored approach:
1. Exports TRN_STREET_RIVA to the local workspace first
2. Builds field mappings from the target table structure
3. For each renamed field, finds the target field index and explicitly maps the corresponding source field
4. Uses `NO_TEST` schema type which automatically matches fields by name while respecting explicit field mappings for renamed fields

This approach is cleaner and less error-prone than the previous method of modifying output field names after the fact.

https://claude.ai/code/session_01ACf9Dk6FqJq7x7ty3zV9cR