### PR TITLE
Remove FROM_STR->FROM_STREET and TO_STR->TO_STREET from field_renames

### DIFF
--- a/scripts/trn_street_assets.py
+++ b/scripts/trn_street_assets.py
@@ -127,9 +127,9 @@ def step_one_new_hrm_streets(local_gdb: str):
         field_mappings = arcpy.FieldMappings()
         field_mappings.addTable(trn_street_riva_copy)
 
+        # FROM_STREET and TO_STREET in TRN_STREET_RIVA are Long (integer) fields —
+        # they are not populated from FROM_STR/TO_STR (text) during the RIVA load.
         field_renames = {
-            "FROM_STR": "FROM_STREET",
-            "TO_STR": "TO_STREET",
             "GSA_LEFT": "GSA_NAME",
             "ADDDATE": "DATE_ACT",
             "MODDATE": "SYS_DATE",


### PR DESCRIPTION
FROM_STREET and TO_STREET in TRN_STREET_RIVA are Long (integer) fields. Mapping text FROM_STR/TO_STR to them produced 0. The 2024 manual append left both fields with no source input; all existing rows have them null.

https://claude.ai/code/session_01ACf9Dk6FqJq7x7ty3zV9cR