### PR TITLE
Add event table update utility for LRS attribute population

### DIFF
--- a/scripts/event_updates.py
+++ b/scripts/event_updates.py
@@ -1,0 +1,105 @@
+import arcpy
+
+
+def update_riva_from_event_table(
+    riva_fc: str,
+    event_table: str,
+    event_field: str,
+    target_field: str,
+    segmented_table: str,
+    active_only: bool = True,
+    riva_filter: str = "DATE_RET IS NULL",
+) -> int:
+    """
+    Update a single field in TRN_STREET_RIVA from a matching LRS event table.
+
+    Join path:
+        TRN_STREET_RIVA.FDMID
+        → segmented_table (FDMID, ROUTE_ID, FROMMEASURE, TOMEASURE)
+        → event_table     (ROUTEID, FROMMEASURE, TOMEASURE, <event_field>)
+
+    When multiple events overlap a RIVA segment the event with the greatest
+    measure overlap wins.  Assumes segmented_table uses ROUTE_ID (not ROUTEID)
+    and that event tables use the standard LRS ROUTEID field name.
+
+    Args:
+        riva_fc:          Path to TRN_STREET_RIVA (SDE or local copy).
+        event_table:      Full path to the LRS event table
+                          e.g. os.path.join(SDE, "SDEADM.TRNLRS", "SDEADM.E_Width")
+        event_field:      Attribute field to read from the event table (e.g. "Width").
+        target_field:     Field in TRN_STREET_RIVA to write (e.g. "PAVE_WIDTH").
+        segmented_table:  Path to TRNLRS_segmented_street_events.
+        active_only:      When True (default) reads only events where TODATE IS NULL.
+        riva_filter:      Where clause applied to the TRN_STREET_RIVA update cursor.
+
+    Returns:
+        Number of records updated.
+    """
+
+    # --- 1. FDMID → (route_id, from_measure, to_measure) -------------------------
+    # Filter to active segmentation rows only (TO_DATE IS NULL).
+    print(f"  Building FDMID route/measure index from segmented streets...")
+    fdmid_lookup: dict = {}
+
+    for row in arcpy.da.SearchCursor(
+        segmented_table,
+        ["FDMID", "ROUTE_ID", "FROMMEASURE", "TOMEASURE"],
+        "FDMID IS NOT NULL AND TO_DATE IS NULL",
+    ):
+        fdmid, route_id, from_m, to_m = row
+        if fdmid not in fdmid_lookup:
+            fdmid_lookup[fdmid] = (route_id, from_m or 0.0, to_m or 0.0)
+
+    print(f"  {len(fdmid_lookup)} FDMID entries indexed.")
+
+    # --- 2. ROUTEID → [(from_m, to_m, value), ...] from event table ---------------
+    where = "TODATE IS NULL" if active_only else None
+    route_events: dict = {}
+
+    print(f"  Reading '{event_field}' from {event_table}...")
+    for row in arcpy.da.SearchCursor(
+        event_table,
+        ["ROUTEID", "FROMMEASURE", "TOMEASURE", event_field],
+        where,
+    ):
+        route_id, from_m, to_m, value = row
+        if value is None:
+            continue
+        route_events.setdefault(route_id, []).append((from_m or 0.0, to_m or 0.0, value))
+
+    print(f"  {sum(len(v) for v in route_events.values())} active event records read.")
+
+    # --- 3. Update RIVA via best-overlap matching ----------------------------------
+    print(f"  Updating {target_field} in {riva_fc}...")
+    updated = 0
+
+    with arcpy.da.UpdateCursor(riva_fc, ["FDMID", target_field], riva_filter) as cursor:
+        for row in cursor:
+            fdmid = row[0]
+
+            seg = fdmid_lookup.get(fdmid)
+            if not seg:
+                continue
+
+            route_id, seg_from, seg_to = seg
+            events = route_events.get(route_id, [])
+            if not events:
+                continue
+
+            # Pick the event with the greatest overlap with this RIVA segment.
+            best_value = None
+            best_overlap = 0.0
+
+            for ev_from, ev_to, value in events:
+                overlap = min(seg_to, ev_to) - max(seg_from, ev_from)
+                if overlap > best_overlap:
+                    best_overlap = overlap
+                    best_value = value
+
+            if best_value is not None and best_overlap > 0:
+                row[1] = best_value
+                cursor.updateRow(row)
+                updated += 1
+
+    print(f"  {target_field}: {updated} records updated.")
+    return updated

--- a/scripts/trn_street_assets.py
+++ b/scripts/trn_street_assets.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime
 
 from gispy import utils
+from event_updates import update_riva_from_event_table
 
 # Settings
 arcpy.SetLogHistory(False)
@@ -17,6 +18,9 @@ E_STREET_STATUS = os.path.join(SDE, "SDEADM.TRNLRS", "SDEADM.E_StreetStatus")
 
 TRN_STREET_RIVA = os.path.join(SDE, "SDEADM.TRN_STREET_RIVA")
 AA_TRN_STREET_RIVA = os.path.join(SDE, "ASSET_ACCOUNTING.TRN_STREET_RIVA")
+
+# LRS event tables — attributes not included in TRNLRS_TRN_STREET_VW dynamic segmentation
+E_WIDTH = os.path.join(SDE, "SDEADM.TRNLRS", "SDEADM.E_Width")
 
 PROJECT_DIR = os.path.dirname(os.getcwd())
 SCRIPTS_DIR = os.path.join(PROJECT_DIR, "scripts")
@@ -434,6 +438,15 @@ if __name__ == "__main__":
 
     # STEP 3
     step_three_updating_existing_riva_streets(new_riva_streets)
+
+    # STEP 3b: Populate event-table attributes not carried by TRNLRS_TRN_STREET_VW
+    # update_riva_from_event_table(
+    #     riva_fc=new_riva_streets,
+    #     event_table=E_WIDTH,
+    #     event_field="Width",
+    #     target_field="PAVE_WIDTH",
+    #     segmented_table=TRNLRS_SEGMENTED,
+    # )
 
     # STEP 4
     step_four_validation_review(local_workspace, new_riva_streets)


### PR DESCRIPTION
## Summary
This PR introduces a new utility function to populate TRN_STREET_RIVA attributes from LRS event tables, enabling attributes not carried by the standard dynamic segmentation view to be synchronized.

## Key Changes
- **New module**: `scripts/event_updates.py` with `update_riva_from_event_table()` function
  - Joins RIVA segments to LRS event tables via a segmented streets lookup table
  - Implements best-overlap matching when multiple events intersect a single RIVA segment
  - Supports filtering to active records only (TODATE IS NULL)
  - Returns count of updated records for logging/validation

- **Updated**: `scripts/trn_street_assets.py`
  - Imports the new event update utility
  - Adds E_WIDTH event table path constant
  - Includes commented-out call to `update_riva_from_event_table()` as STEP 3b in the main workflow (ready for activation)

## Implementation Details
The join path follows: `TRN_STREET_RIVA.FDMID` → segmented streets table (FDMID, ROUTE_ID, measures) → event table (ROUTEID, measures, attributes). When multiple events overlap a segment, the event with the greatest measure overlap is selected. The function uses in-memory dictionaries for efficient lookups across potentially large event tables.

https://claude.ai/code/session_01VHHSdmWTU794aoLzBsigRQ